### PR TITLE
check for local/remote resource before fetching image

### DIFF
--- a/apps/pixoo64_media_album_art/pixoo64_media_album_art.py
+++ b/apps/pixoo64_media_album_art/pixoo64_media_album_art.py
@@ -310,7 +310,6 @@ class Pixoo64_Media_Album_Art(hass.Hass):
     def get_image(self, picture):
         try:
             # check if entity_picture is a local or remote resource
-            self.log(picture)
             if picture.startswith("/"):
                 response = requests.get(f"{self.HA_URL}{picture}")
             else:

--- a/apps/pixoo64_media_album_art/pixoo64_media_album_art.py
+++ b/apps/pixoo64_media_album_art/pixoo64_media_album_art.py
@@ -309,7 +309,13 @@ class Pixoo64_Media_Album_Art(hass.Hass):
 
     def get_image(self, picture):
         try:
-            response = requests.get(f"{self.HA_URL}{picture}")
+            # check if entity_picture is a local or remote resource
+            self.log(picture)
+            if picture.startswith("/"):
+                response = requests.get(f"{self.HA_URL}{picture}")
+            else:
+                response = requests.get(f"{picture}")
+
             img = Image.open(BytesIO(response.content))
             img = img.convert("RGB")
             


### PR DESCRIPTION
pixoo64-media-album art concates HA_URL with the value found in media_player.entity_picture, but entity_picture can contain a full URL instead of a path relative to HA_URL (there's also a property entity_picture_local, but usage of those two entity properties are not consistent between different media player integrations).

The chromecast integration is an example where entity_picture is the full path to the CDN and entity_picture_local the relative one to a local proxy and therefore the script fails to fetch an image because it tries, e.g. "[http://192.168.0.10:8123https://i.scdn.com/](http://192.168.0.10:8123https//i.scdn.com/)....")

This PR adds a quick fix that checks if entity_picture is a relative (starting with "/") or absolute path (everything else) and depending on that concats the value of the property with HA_URL or not.