### PR TITLE
Fix album art not showing when resuming song midway

### DIFF
--- a/apps/pixoo64_media_album_art/pixoo64_media_album_art.py
+++ b/apps/pixoo64_media_album_art/pixoo64_media_album_art.py
@@ -3840,6 +3840,11 @@ class Pixoo64_Media_Album_Art(hass.Hass):
 
                 # ONLY return early if the track matches AND we are actively playing.
                 if not self.media_data.track_changed and current_state_check in ["playing", "on"]:
+                    if not self.is_art_visible:
+                        # If track is resumed from midway when album art is not showing do a full update so album art starts showing.
+                        await self.update_attributes(entity, attribute, old, new, kwargs)
+                        return
+
                     self.progress_timer_gen_id += 1
                     await self._update_progress_bar_loop()
                     if self.lyrics_active_mode:


### PR DESCRIPTION
If you pause media while playing and wait long enough for the album art to stop showing, then resume the song, the album art does not show up until the next song starts. This also happens if you start playing a song from halfway through, ex. if the song is paused midway through on Spotify, then you connect to the media device and start playback.

This PR attempts to fix it by adding a call to `update_attributes`, which in turn calls `pixoo_run` to start displaying the album art. I've tested this locally and it seems to work well for me.

Here's my config:
```
pixoo64_media_album_art:
    module: pixoo64_media_album_art
    class: Pixoo64_Media_Album_Art
    home_assistant:
        media_player: "media_player.living_room_nest"    # The entity ID of your media player.
        
        spotify_client_id: "xyz"
        spotify_client_secret: "abc"
        tidal_client_id: False                              # TIDAL API client ID.
        tidal_client_secret: False                          # TIDAL client secret.
        last.fm: False                                      # Last.fm API key.
        discogs: False                                      # Discogs API key.

    pixoo:
        url: "123"                        # The IP address of your Pixoo64 device.
        full_control: False # Otherwise screen turns off when playback ends
        show_text:
          enabled: True                                    # Display artist and track title.
          clean_title: True                                 # Remove metadata like "Remastered", file extensions, etc.
          text_background: True                             # Add background behind text for better contrast.
          special_mode_spotify_slider: False                # Enable animated album slider when using special mode.
          force_font_color: False                           # Force text color (e.g., "#FFFFFF" for white).
          burned: False                                     # Enable static (non-animated) burned text above the image.
          top_text: False

    progress_bar:
        enabled: True                                     # Master switch for the feature
        entity: "input_boolean.pixoo64_progress_bar"      # Helper to toggle via dashboard
        color: "match"                                    # "match" (auto-contrast) or hex "#FF0000"
        y_offset: 64                                      # Vertical position (1-64)
```